### PR TITLE
Update 'fetch' variable reference

### DIFF
--- a/imgur-client/src/utils/api.jsx
+++ b/imgur-client/src/utils/api.jsx
@@ -4,7 +4,7 @@ var apiKey = '430d6820d865788';
 
 module.exports = {
   get: function(url) {
-    return fetch(rootUrl + url, {
+    return Fetch(rootUrl + url, {
       headers: {
         'Authorization': 'Client-ID ' + apiKey
       }


### PR DESCRIPTION
Updated method name to reflect the variable we created at the top of this class. Should be capitalized or else it will use the browser's version of 'fetch' off the window object and not the polyfill that we intend to use by requiring it.
